### PR TITLE
Fix: Update prepare-upload.py

### DIFF
--- a/snapmaker/scripts/prepare-upload.py
+++ b/snapmaker/scripts/prepare-upload.py
@@ -17,7 +17,7 @@ if upload_protocol.startswith("jlink"):
         commands = [
             "h",
             "loadbin %s, %s" % (source, board.get(
-                "upload.offset_address", "0x08009800")),
+                "upload.offset_address", "0x0800B800")),
             "r",
             "q"
         ]


### PR DESCRIPTION
Fix: Correct jlink upload memory destination

The present value of 0x0800 9800 does not boot because it places the bin into the middle of the Power Panic address range and additionally overrwrites the EEPROM. The linker script and macros.h definition for FLASH_MARLIN both point to 0800 B800 as the correct upload destination.