### PR TITLE
Fix: Fix RingBuffer::Free

### DIFF
--- a/snapmaker/src/utils/ring_buffer.h
+++ b/snapmaker/src/utils/ring_buffer.h
@@ -121,7 +121,7 @@ class RingBuffer {
 
   int32_t Free() {
     int32_t delta = (int32_t)(tail_ - head_);
-    return (delta >= 0)? (size_ - delta) : (size_ + delta);
+    return (delta >= 0)? (size_ - delta) : -delta;
   }
 
   void Reset() {


### PR DESCRIPTION
The old version reported the number of used positions instead of the number of free ones if `head_` was bigger than `tail_`.