### PR TITLE
Fix: Fix FreeRTOS delays

### DIFF
--- a/snapmaker/src/common/protocol_sstp.cpp
+++ b/snapmaker/src/common/protocol_sstp.cpp
@@ -76,7 +76,7 @@ ErrCode ProtocolSSTP::Parse(ring_buffer *rb, uint8_t *out, uint16_t &size) {
 
   // if it doesn't have enough bytes in ring buffer for header, just return
   while (rb_full_count(rb) < (SSTP_PDU_HEADER_SIZE - 1)) {
-    vTaskDelay(portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(1));
     if (++timeout > TIMEOUT_FOR_HEADER) {
       SERIAL_ECHOLN(LOG_HEAD "timeout to wait for PDU header");
       return E_NO_HEADER;
@@ -93,7 +93,7 @@ ErrCode ProtocolSSTP::Parse(ring_buffer *rb, uint8_t *out, uint16_t &size) {
       if (c != -1)
         break;
       else {
-        vTaskDelay(portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(1));
         if (++timeout > TIMEOUT_FOR_NEXT_BYTE) {
           SERIAL_ECHOLNPAIR(LOG_HEAD "not enough bytes for header, just got ", i);
           return E_NO_HEADER;
@@ -123,7 +123,7 @@ ErrCode ProtocolSSTP::Parse(ring_buffer *rb, uint8_t *out, uint16_t &size) {
 
   timeout = 0;
   while (rb_full_count(rb) < length) {
-    vTaskDelay(DELAY_MS_FOR_DATA);
+    vTaskDelay(pdMS_TO_TICKS(DELAY_MS_FOR_DATA));
     if (++timeout > TIMEOUT_COUNT_FOR_DATA) {
       SERIAL_ECHOLNPAIR(LOG_HEAD "not enough bytes for data: ", length);
       return E_NO_DATA;
@@ -138,7 +138,7 @@ ErrCode ProtocolSSTP::Parse(ring_buffer *rb, uint8_t *out, uint16_t &size) {
       if (c != -1)
         break;
       else {
-        vTaskDelay(portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(1));
         if (++timeout > TIMEOUT_FOR_NEXT_BYTE) {
           SERIAL_ECHOLN(LOG_HEAD "timeout wait for next byte of data");
           return E_NO_DATA;

--- a/snapmaker/src/common/protocol_sstp.h
+++ b/snapmaker/src/common/protocol_sstp.h
@@ -54,9 +54,6 @@
 
 #define SSTP_TIMEOUT_FOR_HEADER    (2)
 
-#define SSTP_DELAY_FOR_DATA        (2*portTICK_PERIOD_MS)
-#define SSTP_TIMEOUT_FOR_DATA      (1000/DELAY_FOR_DATA)
-
 #define SSTP_TIMEOUT_FOR_NEXT_BYTE (1)
 
 #define SSTP_INVALID_EVENT_ID      ((uint16_t)0x100)
@@ -67,9 +64,9 @@
 #define SSTP_HEADER_SIZE   8
 
 // timeout to wait for header field
-#define SSTP_HEADER_TIMEOUT  (portTICK_PERIOD_MS*10)
+#define SSTP_HEADER_TIMEOUT  (10)
 // timeout to wait for data field
-#define SSTP_DATA_TIMEOUT    (portTICK_PERIOD_MS*1000)
+#define SSTP_DATA_TIMEOUT    (1000)
 
 #define SSTP_EVENT_ID_INVALID (0xFFFF)
 #define SSTP_OP_CODE_INVALID  (0xFFFF)

--- a/snapmaker/src/module/linear.cpp
+++ b/snapmaker/src/module/linear.cpp
@@ -49,7 +49,7 @@ LinearAxisType Linear::DetectAxis(MAC_t &mac, uint8_t &endstop) {
   for (i = LINEAR_AXIS_X1; i <= LINEAR_AXIS_Z1; i++)  {
     WRITE(pins[i], HIGH);
 
-    vTaskDelay(portTICK_PERIOD_MS * 10);
+    vTaskDelay(pdMS_TO_TICKS(10));
 
     cmd.data[MODULE_EXT_CMD_INDEX_ID]   = MODULE_EXT_CMD_CONFIG_REQ;
     cmd.data[MODULE_EXT_CMD_INDEX_DATA] = i;
@@ -242,7 +242,7 @@ ErrCode Linear::PollEndstop(LinearAxisType axis) {
 
     message.id = endstop_msg_[i];
     canhost.SendStdCmd(message);
-    vTaskDelay(portTICK_PERIOD_MS * 10);
+    vTaskDelay(pdMS_TO_TICKS(10));
   }
 
   return E_SUCCESS;

--- a/snapmaker/src/module/module_base.cpp
+++ b/snapmaker/src/module/module_base.cpp
@@ -181,7 +181,7 @@ ErrCode ModuleBase::InitModule8p(MAC_t &mac, int dir_pin, uint8_t index) {
   cmd.data[MODULE_EXT_CMD_INDEX_DATA] = index;
 
   WRITE(dir_pin, HIGH);
-  vTaskDelay(portTICK_PERIOD_MS * 10);
+  vTaskDelay(pdMS_TO_TICKS(10));
 
   // didn't get ack from module
   if (canhost.SendExtCmdSync(cmd, 500) != E_SUCCESS)

--- a/snapmaker/src/module/toolhead_3dp.cpp
+++ b/snapmaker/src/module/toolhead_3dp.cpp
@@ -142,20 +142,20 @@ ErrCode ToolHead3DP::Init(MAC_t &mac, uint8_t mac_index) {
   mac_index_ = mac_index;
 
   // read the state of sensors
-  vTaskDelay(portTICK_PERIOD_MS * 5);
+  vTaskDelay(pdMS_TO_TICKS(5));
 
   if (msg_id_index_probe != 0xff) {
     mesg_cmd.id = message_id[msg_id_index_probe];
     canhost.SendStdCmd(mesg_cmd);
   }
 
-  vTaskDelay(portTICK_PERIOD_MS * 5);
+  vTaskDelay(pdMS_TO_TICKS(5));
   if (msg_id_index_runout != 0xff) {
     mesg_cmd.id = message_id[msg_id_index_runout];
     canhost.SendStdCmd(mesg_cmd);
   }
 
-  vTaskDelay(portTICK_PERIOD_MS * 5);
+  vTaskDelay(pdMS_TO_TICKS(5));
 
   LOG_I("\tprobe: 0x%x, filament: 0x%x\n", probe_state_, filament_state_);
 

--- a/snapmaker/src/module/toolhead_laser.cpp
+++ b/snapmaker/src/module/toolhead_laser.cpp
@@ -256,7 +256,7 @@ ErrCode ToolHeadLaser::GetFocus(SSTP_Event_t &event) {
   uint8_t  buff[5];
 
   LoadFocus();
-  vTaskDelay(portTICK_PERIOD_MS * 20);
+  vTaskDelay(pdMS_TO_TICKS(20));
 
   LOG_I("SC get Focus: %.2f mm\n", focus_ / 1000.0f);
 
@@ -482,7 +482,7 @@ ErrCode ToolHeadLaser::ReadBluetoothInfo(LaserCameraCommand cmd, uint8_t *out, u
 
     esp32_.Send(event);
     esp32_.FlushOutput();
-    vTaskDelay(200 * portTICK_PERIOD_MS * i);
+    vTaskDelay(pdMS_TO_TICKS(200 * i));
 
     ret = esp32_.CheckoutCmd(out, length);
     if (ret != E_SUCCESS) {
@@ -534,7 +534,7 @@ ErrCode ToolHeadLaser::SetBluetoothInfo(LaserCameraCommand cmd, uint8_t *info, u
 
     esp32_.Send(event);
     esp32_.FlushOutput();
-    vTaskDelay(200 * portTICK_PERIOD_MS * i);
+    vTaskDelay(pdMS_TO_TICKS(200 * i));
 
     ret = esp32_.CheckoutCmd(buffer, length);
     if (ret != E_SUCCESS) {

--- a/snapmaker/src/service/system.cpp
+++ b/snapmaker/src/service/system.cpp
@@ -350,7 +350,7 @@ ErrCode SystemService::ResumeTrigger(TriggerSource source) {
   }
 
   // send event to marlin task to handle
-  if (xMessageBufferSend(sm2_handle->event_queue, event, 2, portTICK_PERIOD_MS * 100)) {
+  if (xMessageBufferSend(sm2_handle->event_queue, event, 2, pdMS_TO_TICKS(100))) {
     cur_status_ = SYSTAT_RESUME_TRIG;
     return E_SUCCESS;
   }

--- a/snapmaker/src/snapmaker.cpp
+++ b/snapmaker/src/snapmaker.cpp
@@ -94,7 +94,7 @@ void HeatedBedSelfCheck(void) {
   OUT_WRITE(HEATER_BED_PIN, LOW);
   // and set input for the detect pin
   SET_INPUT_PULLUP(HEATEDBED_ON_PIN);
-  vTaskDelay(portTICK_PERIOD_MS * 10);
+  vTaskDelay(pdMS_TO_TICKS(10));
   // if we get LOW, indicate the NMOS is breakdown
   // we need to disable its power supply immediately
   if(READ(HEATEDBED_ON_PIN) == LOW) {
@@ -143,7 +143,7 @@ static void main_loop(void *param) {
   systemservice.SetCurrentStatus(SYSTAT_IDLE);
 
   // waiting for initializing modules
-  xEventGroupWaitBits(((SnapmakerHandle_t)param)->event_group, EVENT_GROUP_MODULE_READY, pdFALSE, pdTRUE, portTICK_PERIOD_MS * 10000);
+  xEventGroupWaitBits(((SnapmakerHandle_t)param)->event_group, EVENT_GROUP_MODULE_READY, pdFALSE, pdTRUE, pdMS_TO_TICKS(10000));
 
   // init power-loss recovery after initializing modules
   // because we need to check if current toolhead is same with previous
@@ -210,7 +210,7 @@ static void hmi_task(void *param) {
       if (++count)
         count = 0;
 
-      vTaskDelay(portTICK_PERIOD_MS * 100);
+      vTaskDelay(pdMS_TO_TICKS(100));
       continue;
     }
     else
@@ -219,14 +219,14 @@ static void hmi_task(void *param) {
     ret = hmi.CheckoutCmd(dispather_param.event_buff, dispather_param.size);
     if (ret != E_SUCCESS) {
       // no command, sleep 10ms for next command
-      vTaskDelay(portTICK_PERIOD_MS * 10);
+      vTaskDelay(pdMS_TO_TICKS(10));
       continue;
     }
 
     // execute or send out one command
     DispatchEvent(&dispather_param);
 
-    vTaskDelay(portTICK_PERIOD_MS * 5);
+    vTaskDelay(pdMS_TO_TICKS(5));
   }
 }
 
@@ -252,7 +252,7 @@ static void heartbeat_task(void *param) {
     }
 
     // sleep for 10ms
-    vTaskDelay(portTICK_PERIOD_MS * 10);
+    vTaskDelay(pdMS_TO_TICKS(10));
   }
 }
 


### PR DESCRIPTION
All over the code in snapmaker/src, the code uses constructs like `vTaskDelay(timeout_ms * portTICK_PERIOD_MS);` to wait for timeout_ms milliseconds. But this uses `portTICK_PERIOD_MS` incorrectly since it stands for the number of milliseconds per tick, not the number of ticks per millisecond. Therefore the code actually would have to use `vTaskDelay(timeout_ms / portTICK_PERIOD_MS);`.
Currently this doesn't cause any issues since `portTICK_PERIOD_MS` is `1`, so both multiplying and dividing are no-ops, but this breaks as soon as someone tries to change the tickrate.

This patch fixes this by using `pdMS_TO_TICKS`. This does not only make the code easier to understand, avoids the trouble of remembering f you have to multiply or divide and is even compatible with higher tickrates.