### PR TITLE
Change Pack Task Name

### DIFF
--- a/snapmaker/scripts/platformio-targets.py
+++ b/snapmaker/scripts/platformio-targets.py
@@ -33,6 +33,6 @@ env.AddCustomTarget(
     actions=[
     "python {0} -d {1} -c {2} ".format(pack_script, project_dir, fw_bin),
     ],
-    title="Core Env",
-    description="Show PlatformIO Core and Python versions"
+    title="Pack",
+    description="Pack Snapmaker Firmware"
 )


### PR DESCRIPTION
This changes the PlatformIO task name from the default of "Core Env" to something readily searchable, "Pack"

New name can be searched in the list of tasks:
![image](https://user-images.githubusercontent.com/7025732/103423724-11f14b80-4b5d-11eb-885f-faf3d9e05a07.png)

Previously it showed up only as this:
![image](https://user-images.githubusercontent.com/7025732/103423741-22092b00-4b5d-11eb-878b-a59177becade.png)
