### PR TITLE
Fix: Fix off-by-two bug

### DIFF
--- a/snapmaker/src/gcode/M1005_1007.cpp
+++ b/snapmaker/src/gcode/M1005_1007.cpp
@@ -66,7 +66,7 @@ void GcodeSuite::M1005() {
       continue;
     }
 
-    buffer[cmd.length + 2] = 0;
+    buffer[cmd.length] = 0;
     LOG_I("0x%08X: %s\n", mac.val, buffer+2);
   }
 


### PR DESCRIPTION
Stops printing weird random characters after the version number in M1005.