### PR TITLE
Bugfix/door detection

### DIFF
--- a/snapmaker/src/module/enclosure.cpp
+++ b/snapmaker/src/module/enclosure.cpp
@@ -145,6 +145,7 @@ void Enclosure::PollDoorState() {
 
 
 void Enclosure::Disable() {
+  enabled_ = false;
   if (event_state_ == ENCLOSURE_EVENT_STATE_HANDLED_OPEN &&
       event_state_ == ENCLOSURE_EVENT_STATE_OPENED) {
     HandleDoorClosed();
@@ -154,6 +155,7 @@ void Enclosure::Disable() {
 
 
 void Enclosure::Enable() {
+  enabled_= true;
   if (door_state_ == ENCLOSURE_DOOR_STATE_OPEN &&
       event_state_ == ENCLOSURE_EVENT_STATE_IDLE) {
     HandleDoorOpened();

--- a/snapmaker/src/module/enclosure.cpp
+++ b/snapmaker/src/module/enclosure.cpp
@@ -151,6 +151,8 @@ void Enclosure::Disable() {
     HandleDoorClosed();
     event_state_ = ENCLOSURE_EVENT_STATE_IDLE;
   }
+
+  LOG_I("Door detection disabled\n");
 }
 
 
@@ -160,6 +162,8 @@ void Enclosure::Enable() {
       event_state_ == ENCLOSURE_EVENT_STATE_IDLE) {
     HandleDoorOpened();
   }
+
+  LOG_I("Door detection enabled\n");
 }
 
 


### PR DESCRIPTION
Assign the _enabled flag and disable door detection on M101 S0.

Not saved in eeprom for laser safety