### PR TITLE
Feature: Add Laser Inline Power control

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -60,6 +60,7 @@
   #include "../snapmaker/src/module/toolhead_3dp.h"
   #include "../snapmaker/src/service/bed_level.h"
   #include "../snapmaker/src/module/linear.h"
+  #include "../snapmaker/src/module/toolhead_laser.h"
 #endif
 
 #if ENABLED(QUICK_HOME)
@@ -192,6 +193,10 @@ void GcodeSuite::G28(const bool always_home_all) {
   if (DEBUGGING(LEVELING)) {
     DEBUG_ECHOLNPGM(">>> G28");
     log_machine_info();
+  }
+  if (laser->IsOnline()) {
+    laser->InlineDisable();
+    laser->TurnOff();
   }
 
   #if ENABLED(DUAL_X_CARRIAGE)

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -114,6 +114,8 @@ uint8_t Planner::delay_before_delivering;       // This counter delays delivery 
 
 planner_settings_t Planner::settings;           // Initialized by settings.load()
 
+laser_state_t Planner::laser_inline;            // Planner laser power for blocks
+
 uint32_t Planner::max_acceleration_steps_per_s2[X_TO_EN]; // (steps/s^2) Derived from mm_per_s2
 
 float Planner::steps_to_mm[X_TO_EN];           // (mm) Millimeters per step
@@ -765,6 +767,11 @@ void Planner::calculate_trapezoid_for_block(block_t* const block, const float &e
     block->cruise_rate = cruise_rate;
   #endif
   block->final_rate = final_rate;
+
+  /**
+   * Laser trapezoid: set entry power
+   */
+  block->laser.power_entry = block->laser.power * entry_factor;
 }
 
 /*                            PLANNER SPEED DEFINITION
@@ -1830,6 +1837,9 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
 
   // Clear all flags, including the "busy" bit
   block->flag = 0x00;
+
+  block->laser.status = laser_inline.status;
+  block->laser.power = laser_inline.power;
 
   // Set direction bits
   block->direction_bits = dm;

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -74,6 +74,16 @@ enum BlockFlag : char {
   BLOCK_FLAG_SYNC_POSITION        = _BV(BLOCK_BIT_SYNC_POSITION)
 };
 
+typedef struct {
+  bool isEnabled:1;
+} laser_power_status_t;
+
+typedef struct {
+  laser_power_status_t status;
+  uint16_t power;            // When in trapezoid mode this is nominal power
+  uint16_t power_entry;      // Entry power for the laser
+} block_inline_laser_t;
+
 /**
  * struct block_t
  *
@@ -159,11 +169,25 @@ typedef struct block_t {
 
   uint32_t filePos;                       // position of gcode of this block in the file
 
+  block_inline_laser_t laser;
+
 } block_t;
 
 #define HAS_POSITION_FLOAT ANY(LIN_ADVANCE, SCARA_FEEDRATE_SCALING, GRADIENT_MIX)
 
 #define BLOCK_MOD(n) ((n)&(BLOCK_BUFFER_SIZE-1))
+
+typedef struct {
+  /**
+  uint32_t max_acceleration_mm_per_s2[X_TO_EN],  // (mm/s^2) M201 XYZE
+   * Laser status flags
+   */
+  laser_power_status_t status;
+  /**
+   * Laser power: 0 to 255;
+   */
+  uint16_t power;
+} laser_state_t;
 
 typedef struct {
   uint32_t max_acceleration_mm_per_s2[X_TO_EN],  // (mm/s^2) M201 XYZE
@@ -240,6 +264,8 @@ class Planner {
     #endif
     static bool is_user_set_lead;                        // M92 Specifies whether to use a user-defined value
     static planner_settings_t settings;
+    
+    static laser_state_t laser_inline;
 
     static uint32_t max_acceleration_steps_per_s2[X_TO_EN]; // (steps/s^2) Derived from mm_per_s2
     static float steps_to_mm[X_TO_EN];          // Millimeters per step

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -345,6 +345,17 @@ class Stepper {
     //
     static int8_t count_direction[NUM_AXIS];
 
+    //
+    // Laser Inline Power Trapezoids
+    //
+    typedef struct {
+      bool enabled;        // Trapezoid needed flag (i.e., laser on, planner in control)
+      uint16_t cur_power;  // Current laser power
+      bool cruise_set;     // Power set up for cruising?
+    } stepper_laser_t;
+
+    static stepper_laser_t laser_trap;
+
   public:
 
     //

--- a/snapmaker/src/gcode/M3-M5.cpp
+++ b/snapmaker/src/gcode/M3-M5.cpp
@@ -62,6 +62,21 @@
  */
 
 void GcodeSuite::M3_M4(const bool is_M4) {
+  float power = NAN; // nullable power
+  if (parser.seen('P'))
+    power = parser.value_float();
+  else if (parser.seen('S'))
+    power = parser.value_float() * 100.0f / 255.0f;
+  
+  if (laser->IsOnline()) {
+    // If no power given treat as non-inline
+    if (parser.seen('I') && !isnan(power)) {
+      laser->SetOutputInline(power);
+      return;
+    }
+
+    laser->InlineDisable();   // Disable planner laser control
+  }
 
   planner.synchronize();   // wait until previous movement commands (G0/G0/G2/G3) have completed before playing with the spindle
 
@@ -72,16 +87,16 @@ void GcodeSuite::M3_M4(const bool is_M4) {
    */
 
   if(laser->IsOnline()) {
-    if(parser.seen('P')) {
-      laser->SetOutput(parser.value_float());
+    if(!isnan(power)) {
+      laser->SetOutput(power);
     }
     else {
       laser->TurnOn();
     }
   }
   else if(cnc.IsOnline()) {
-    if(parser.seen('P'))
-      cnc.SetOutput(parser.value_float());
+    if(!isnan(power))
+      cnc.SetOutput(power);
     else
       cnc.TurnOn();
   }
@@ -91,6 +106,15 @@ void GcodeSuite::M3_M4(const bool is_M4) {
  * M5 turn off spindle
  */
 void GcodeSuite::M5() {
+  if (laser->IsOnline()) {
+    if (parser.seen('I')) {
+        laser->SetOutputInline(0);
+        return;
+    }
+
+    laser->InlineDisable();   // Disable planner laser control
+  }
+  
   planner.synchronize();
   //set_spindle_laser_enabled(false);
   if(laser->IsOnline()) {

--- a/snapmaker/src/module/toolhead_laser.h
+++ b/snapmaker/src/module/toolhead_laser.h
@@ -26,6 +26,8 @@
 
 #include "../hmi/uart_host.h"
 
+#include "src/module/planner.h"
+
 #define TOOLHEAD_LASER_POWER_SAFE_LIMIT   (0.5)
 #define TOOLHEAD_LASER_POWER_NORMAL_LIMIT (100)
 #define TOOLHEAD_LASER_CAMERA_FOCUS_MAX   (65000)  // mm*1000
@@ -91,7 +93,7 @@ enum LASER_10W_STATUS {
 class ToolHeadLaser: public ModuleBase {
   public:
 		ToolHeadLaser(ModuleDeviceID id): ModuleBase(id) {
-      power_limit_ = 100;
+      power_limit_pwm_ = 255;
       power_pwm_   = 0;
       power_val_   = 0;
       mac_index_   = MODULE_MAC_INDEX_INVALID;
@@ -187,7 +189,7 @@ class ToolHeadLaser: public ModuleBase {
     uint16_t timer_in_process_;
     ToolHeadLaserState  state_;
     float power_val_;
-    float power_limit_;
+    uint16_t power_limit_pwm_;
     uint16_t power_pwm_;
     uint8_t  fan_state_;
     uint16_t fan_tick_;
@@ -212,6 +214,22 @@ class ToolHeadLaser: public ModuleBase {
     bool need_to_turnoff_laser_;
     bool need_to_tell_hmi_;
     LASER_10W_STATUS laser_10w_status_;
+  
+  // Laser Inline Power functions
+  public:
+    /**
+     * Inline power adds extra fields to the planner block
+     * to handle laser power and scale to movement speed.
+     */
+
+    // Force disengage planner power control
+    void InlineDisable();
+
+    // Set the power for subsequent movement blocks
+    void SetOutputInline(float power);
+
+    // Optimized TurnOn function for use from the Stepper ISR
+    void TurnOn_ISR(uint16_t power_pwm);
 };
 
 


### PR DESCRIPTION
This pull request adds a new feature: Laser Inline Power. This greatly enhances job completion time and quality for many types of jobs.

This pull request implements a feature from Marlin that was added to Marlin after Snapmaker forked. This addition is based on the work contained in this pull: https://github.com/MarlinFirmware/Marlin/pull/15335. Inline laser power is also a standard feature on GRBL firmware, another common laser cutter firmware.

### Summary of New Features
- Enables optional use of inline power control by using a new I parameter on `M3`-`M5` in the form of `M3 Pxx I` (https://marlinfw.org/docs/gcode/M003.html)
- Increases compatibility by adding traditional power specified with the 0-255 S parameter in form of `M3 Sxx`
- Adds optional new parameter `Sxx` and `Pxx` to `G0`-`G3` movement commands to move with inline laser power specified in the form of `G1 Yxx Pxx`. (https://marlinfw.org/docs/gcode/G000-G001.html)
- A `G28` home command disables the laser for enhanced safety.
- Increases compatibility by adding traditional power specified with the 0-255 S parameter in form of `M3 Sxx`

### Additional Changes
- A `G28` home command disables the laser for enhanced safety.
- Modified how the fan and power limits are controlled in `toolhead_laser.cpp` to accommodate calls from within the stepper ISR by not triggering CAN communications within the ISR.
- Removes handler for unsupported air assist / coolant controls so that they return the standard unknown gcode handler so as to properly communicate to controlling software that air assist is unavailable.

When not enabling laser inline power the machine behaves the same as previous firmware, with the exception of the change made to `G28`.

### Description of Laser Inline Power Behavior
When enabled by using the `I` parameter laser control is moved into the planner and motion control modules to allow for smooth power changes.

**First a review of previous laser power control:**
The `M3` command first calls `planner.synchronize();` which waits for all motion to complete. The machine decelerates and comes to a stop, then the laser power is changes, and then the machine accelerates to continue. Each deceleration/acceleration results in additional dwell that affects the accuracy of dwell timing, resulting in a slightly darker than intended laser burn. This is most pronounced when using continuously variable power in software like Lightburn (Lightburn calls this 'grayscale' mode, which is not dithered).

**New behavior of laser inline power**
Control of the laser power has been moved into the planner and stepper ISR. The planner adds the requested power onto the motion block. As the blocks are executed in the stepper ISR the laser power is scaled with acceleration trapezoid to eliminate darkening caused by the machine moving at less than the commanded speed with the full laser power.
![image](https://user-images.githubusercontent.com/7025732/137256766-a3f7e4df-7c1a-4672-8c68-fe8c84da3362.png)

As the laser power is being controlled via the planner the `planner.synchronize();` is not necessary which allows the machine to use optimized exit and entry velocities similar to 3D printing.

**Comparison between old and new behavior**
Here is a sample from a job using grayscale mode from Lightburn without laser inline power. Each concentric circle on the left and vertical line on the right is where the laser power changed, resulting in a pause as the motion came to a stop and resumed.
![image](https://user-images.githubusercontent.com/7025732/137254443-7a224ea0-2bff-4c1b-a137-e5d9faa247bc.png)

By enabling laser inline power and eliminating harmful motion pauses the job completes approximately 2x faster and is of higher quality.
![image](https://user-images.githubusercontent.com/7025732/137254610-1fed1b8b-1417-4d60-8306-83c929706be4.png)

When Lightburn or other software is configured to use inline power it generates gcode similar to the following:
```text
G1 X0.3 S131.3
G1 X0.7 S130.1
G1 X0.1 S129.5
G1 X0.8 S128.9
```
