### PR TITLE
Update G1029.cpp

### DIFF
--- a/Marlin/src/gcode/bedlevel/abl/G1029.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G1029.cpp
@@ -108,7 +108,6 @@ void GcodeSuite::G1029() {
   const bool seen_a = parser.seen("A");
   if (seen_a) {
 
-    thermalManager.disable_all_heaters();
     process_cmd_imd("G28");
     set_bed_leveling_enabled(false);
 


### PR DESCRIPTION
removed command that disables heaters - we need to be able to do bed levelling with 1029 and whatever temp we need.

