### PR TITLE
Limit laser power lookup to table size

### DIFF
--- a/snapmaker/src/module/toolhead_laser.cpp
+++ b/snapmaker/src/module/toolhead_laser.cpp
@@ -253,11 +253,14 @@ void ToolHeadLaser::SetPower(float power) {
   if (state_ == TOOLHEAD_LASER_STATE_OFFLINE)
     return;
 
+  // limit to valid range of the table
+  LIMIT(power, 0.0f, 100.0f);
   power_val_ = power;
 
   integer = (int)power;
   decimal = power - integer;
 
+  // even if random data is read by exceeding the table data, it will be discarded when multiplying by 0
   power_pwm_ = (uint16_t)(power_table_[integer] + (power_table_[integer + 1] - power_table_[integer]) * decimal);
 
   if (power_pwm_ > power_limit_pwm_)


### PR DESCRIPTION
Summary:
Credit to @brent113 for finding this originally.

The issue is that we are allowed to call `ToolHeadLaser::SetPower` with
any value, and it will attempt to do the conversion through the
`power_table_` using that value.

This means that calling `ToolHeadLaser::SetPower` with any value above
100 will result in reading random data and attempting to set that as the
PWM value.

To fix, we should clamp `power` to the size of the `power_table_` when
doing any lookups.

Test Plan:
`pio run`
I also wrote a test of sorts (http://tpcg.io/AMS3HP), but it'd be better
if I could write a proper test for this method.