### PR TITLE
Fix: Disable inline power in TurnOff

### DIFF
--- a/snapmaker/src/module/toolhead_laser.cpp
+++ b/snapmaker/src/module/toolhead_laser.cpp
@@ -231,6 +231,7 @@ void ToolHeadLaser::TurnOff() {
       laser_10w_tick_ = 0;
     }
   }
+  laser->InlineDisable();
   state_ = TOOLHEAD_LASER_STATE_OFF;
   CheckFan(0);
   tim_pwm(0);


### PR DESCRIPTION
When @brent113 wrote the inline controls, the M5 gcode would be executed when stopping a job through the HMI.

This doesn't appear to be the case anymore, and the HMI calls `TurnOff` directly in `SystemService::PreProcessStop`. However, when `TurnOff` is called, there could still be blocks in the planner, and the planner will continue to execute those blocks after `TurnOff` was called.

This ends up causing the issue that the laser can be turned back on by the planner finishing the next block, and there's nothing that will disable the laser afterwards.

If we add a `InlineDisable` into `TurnOff`, we can be sure to not turn the laser back on as the planner finishes the block.

Test plan:
See #221 for reproduction steps

Before, the laser would potentially stay on if cancelled while an inline power block was in the queue.
After, the laser properly shuts off even if there's inline power blocks in the queue.