### PR TITLE
Fix: Disable inline power in TurnOff

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -195,7 +195,6 @@ void GcodeSuite::G28(const bool always_home_all) {
     log_machine_info();
   }
   if (laser->IsOnline()) {
-    laser->InlineDisable();
     laser->TurnOff();
   }
 

--- a/snapmaker/src/gcode/M3-M5.cpp
+++ b/snapmaker/src/gcode/M3-M5.cpp
@@ -68,14 +68,9 @@ void GcodeSuite::M3_M4(const bool is_M4) {
   else if (parser.seen('S'))
     power = parser.value_float() * 100.0f / 255.0f;
   
-  if (laser->IsOnline()) {
-    // If no power given treat as non-inline
-    if (parser.seen('I') && !isnan(power)) {
-      laser->SetOutputInline(power);
-      return;
-    }
-
-    laser->InlineDisable();   // Disable planner laser control
+  if (laser->IsOnline() && parser.seen('I') && !isnan(power)) {
+    laser->SetOutputInline(power);
+    return;
   }
 
   planner.synchronize();   // wait until previous movement commands (G0/G0/G2/G3) have completed before playing with the spindle
@@ -108,13 +103,9 @@ void GcodeSuite::M3_M4(const bool is_M4) {
  * M5 turn off spindle
  */
 void GcodeSuite::M5() {
-  if (laser->IsOnline()) {
-    if (parser.seen('I')) {
-        laser->SetOutputInline(0);
-        return;
-    }
-
-    laser->InlineDisable();   // Disable planner laser control
+  if (laser->IsOnline() && parser.seen('I')) {
+    laser->SetOutputInline(0);
+    return;
   }
   
   planner.synchronize();

--- a/snapmaker/src/module/toolhead_laser.cpp
+++ b/snapmaker/src/module/toolhead_laser.cpp
@@ -231,6 +231,7 @@ void ToolHeadLaser::TurnOff() {
       laser_10w_tick_ = 0;
     }
   }
+  laser->InlineDisable();
   state_ = TOOLHEAD_LASER_STATE_OFF;
   CheckFan(0);
   tim_pwm(0);


### PR DESCRIPTION
When a job is aborted in the touchscreen, the HMI calls `TurnOff` directly in `SystemService::PreProcessStop`. However, when `TurnOff` is called, there could still be blocks in the planner, and the planner will continue to execute those blocks after `TurnOff` was called.

This ends up causing the issue that the laser can be turned back on by the planner finishing the next block, and there's nothing that will disable the laser afterwards.

If we add a `InlineDisable` into `TurnOff`, we can be sure to not turn the laser back on as the planner finishes the block. We can also remove the calls to `InlineDisable()` in the various gcode methods since they will now have `InlineDisable()` called as a part of `TurnOff()`.

Test plan:
See issue #221 for reproduction steps.

Before, the laser would potentially stay on if cancelled while an inline power block was in the queue.
After, the laser properly shuts off even if there's inline power blocks in the queue.