### PR TITLE
Enabled the option QUICK_HOME

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -478,7 +478,7 @@
 #define Z_HOME_BUMP_MM 3
 #define B_HOME_BUMP_MM 0
 #define HOMING_BUMP_DIVISOR { 9, 9, 10, 1}  // Re-Bump Speed Divisor (Divides the Homing Feedrate)
-//#define QUICK_HOME                     // If homing includes X and Y, do a diagonal move initially
+#define QUICK_HOME                     // If homing includes X and Y, do a diagonal move initially
 
 // When G28 is called, this option will make Y home before X
 //#define HOME_Y_BEFORE_X


### PR DESCRIPTION
To home X and Y at the same time after z to save a bit of time, the already existing option in marlin has been enabled.

This relates to https://github.com/Snapmaker/Snapmaker2-Controller/issues/230