### PR TITLE
Fix: fixing a bug in `scripts/cat-env.py`

### DIFF
--- a/snapmaker/scripts/cat-env.py
+++ b/snapmaker/scripts/cat-env.py
@@ -6,7 +6,7 @@ Import("env", "projenv")
 
 
 print("++++++++++++++++++++++++++++++CPPDEFINES start++++++++++++++++++++++++++++++")
-print(projenv.get("CPPDEFINES", [])[:])
+print(projenv.get("CPPDEFINES", []))
 print("++++++++++++++++++++++++++++++CPPDEFINES end++++++++++++++++++++++++++++++\n")
 
 print("++++++++++++++++++++++++++++++CPPPATH start++++++++++++++++++++++++++++++")


### PR DESCRIPTION
I found that if I run `pio run`, the output is something like below，and I can reproduce this on Mac/Windows.
```
++++++++++++++++++++++++++++++CPPDEFINES start++++++++++++++++++++++++++++++
TypeError: sequence index must be integer, not 'slice':
  File "C:\home\.platformio\penv\Lib\site-packages\platformio\builder\main.py", line 180:
    env.SConscript(env.GetExtraScripts("post"), exports="env")
  File "C:\home\.platformio\packages\tool-scons\scons-local-4.5.2\SCons\Script\SConscript.py", line 598:
    return _SConscript(self.fs, *files, **subst_kw)
  File "C:\home\.platformio\packages\tool-scons\scons-local-4.5.2\SCons\Script\SConscript.py", line 285:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "C:\home\Snapmaker2-Controller\snapmaker\scripts\cat-env.py", line 9:
    print(projenv.get("CPPDEFINES", [])[:])
========================== [FAILED] Took 4.47 seconds ==========================
```

I think this is because that the code `projenv.get("CPPDEFINES", [])` in `cat-env.py` returns a `deque`  which doesn't support the slice operation. Since this is only for showing informations, I think it's ok to remove `[:]` since this doesn't reduce the readability.
