### PR TITLE
Improvement: Set system status to started when print timer started (M75)

### DIFF
--- a/Marlin/src/gcode/stats/M75-M78.cpp
+++ b/Marlin/src/gcode/stats/M75-M78.cpp
@@ -33,7 +33,13 @@
  * M75: Start print timer
  */
 void GcodeSuite::M75() {
-  print_job_timer.start();
+  SSTP_Event_t event;
+  event.id = EID_SYS_CTRL_REQ;
+  event.op_code = SYSCTL_OPC_START_WORK;
+  event.length = 0;
+  planner.synchronize();
+  SERIAL_ECHOPAIR("MC REQ START\n");
+  systemservice.ChangeSystemStatus(event);
   #if ENABLED(EXTENSIBLE_UI)
     ExtUI::onPrintTimerStarted();
   #endif
@@ -58,6 +64,7 @@ void GcodeSuite::M76() {
  * M77: Stop print timer
  */
 void GcodeSuite::M77() {
+ systemservice.SetCurrentStatus(SYSTAT_IDLE);
  print_job_timer.stop();
  #if ENABLED(EXTENSIBLE_UI)
    ExtUI::onPrintTimerStopped();


### PR DESCRIPTION
Add an event to be sent to `systemservice` when a job is marked as started with M75.

Motivation: Currently, when a print is started from octoprint (or anything not the HMI), the `SystemService.cur_status_` is not updated. This then causes us to not handle filament runout, since there's a conditional check that the status must be `SYSTAT_WORK`: https://github.com/Snapmaker/Snapmaker2-Controller/blob/main/Marlin/src/feature/runout.h#L100

Additionally, M75 and M77 are currently "unsupported". I'm assuming that this is just that they are not actually upgraded to work with Snapmaker's cusotmiztions.

We can use M75 and M77 to update the system service status so that runout detection is activated when a print job is "started".

This diff will add the necessary `SystemService` calls to make sure that `SystemService` status is set to `SYSTAT_WORK` when a job is in progress (after M75) and back to `SYSTAT_IDLE` when the job finishes.

By itself, this will have no influence on the operation of the machine, since luban and the HMI do not ever use M75 or M77. However, in combination with some configuration in octoprint, this diff enables the ability for runout detection to be triggered when printing via octoprint.